### PR TITLE
Now we can use self-signed certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ You can lock down your pub/sub nginx endpoints using the [Access Key Module](htt
             'driver' => 'pushstream',
             'base_url' => 'http://localhost',
             'access_key' => md5('foo')
+            'cert' => null
+            // or 'cert' => 'path/to/server.crt' for self-signed certificate
         ]
 
 3.  In your `config/app.php` add the following line to your `providers` array:

--- a/src/Cmosguy/Broadcasting/PushStreamBroadcastManagerProvider.php
+++ b/src/Cmosguy/Broadcasting/PushStreamBroadcastManagerProvider.php
@@ -14,12 +14,18 @@ class PushStreamBroadcastManagerProvider extends ServiceProvider
     {
 
         $this->app->make('Illuminate\Broadcasting\BroadcastManager')->extend('pushstream', function ($app, $config) {
-            return new PushStreamBroadcaster(new Client([
+            $client = new Client([
                 'base_url' => $config['base_url'],
                 'query'    => [
                     'access_key' => $config['access_key']
                 ]
-            ]));
+            ]);
+            
+            if (!empty($config['cert'])) {
+                $client->setDefaultOption('verify', $config['cert']);
+            }
+
+            return new PushStreamBroadcaster($client);
         });
     }
 


### PR DESCRIPTION
In config write option **cert** with path to server certificate file

```
'pushstream' => [
        'driver' => 'pushstream',
        'base_url' => 'https://test-api.tachcard.com',
        'access_key' => md5('pushstream_pass'),
        'cert' => '/var/www/server.crt'
]
```
